### PR TITLE
Bump actions/checkout from v2 to v2.3.3

### DIFF
--- a/combine-prs.yml
+++ b/combine-prs.yml
@@ -82,7 +82,7 @@ jobs:
             console.log('Combined: ' + combined);
             return combined
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.3
         with:
           fetch-depth: 0
       # Creates a branch with other PR branches merged together


### PR DESCRIPTION
Latest release for actions/checkout is v2.3.3
See https://github.com/actions/checkout/releases/tag/v2.3.3 for release notes/change-log.