### PR TITLE
Change combineable -> combinable

### DIFF
--- a/combine-prs.yml
+++ b/combine-prs.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       branchPrefix:
-        description: 'Branch prefix to find combineable PRs based on'
+        description: 'Branch prefix to find combinable PRs based on'
         required: true
         default: 'dependabot'
       mustBeGreen:


### PR DESCRIPTION
I think the right spelling is `combinable` instead of `combineable`, but I'm willing to be corrected on this. :smile: