### PR TITLE
Use /check-runs instead of /status to support repos using GitHub Actions for CI

### DIFF
--- a/combine-prs.yml
+++ b/combine-prs.yml
@@ -51,16 +51,15 @@ jobs:
                 statusOK = true;
                 if(${{ github.event.inputs.mustBeGreen }}) {
                   console.log('Checking green status: ' + branch);
-                  const statuses = await github.paginate('GET /repos/{owner}/{repo}/commits/{ref}/status', {
+                  const checkRuns = await github.request('GET /repos/{owner}/{repo}/commits/{ref}/check-runs', {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     ref: branch
                   });
-                  if(statuses.length > 0) {
-                    const latest_status = statuses[0]['state'];
-                    console.log('Validating status: ' + latest_status);
-                    if(latest_status != 'success') {
-                      console.log('Discarding ' + branch + ' with status ' + latest_status);
+                  for await (const cr of checkRuns.data.check_runs) {
+                    console.log('Validating check conclusion: ' + cr.conclusion);
+                    if(cr.conclusion != 'success') {
+                      console.log('Discarding ' + branch + ' with check conclusion ' + cr.conclusion);
                       statusOK = false;
                     }
                   }
@@ -91,7 +90,7 @@ jobs:
 
             core.setOutput('base-branch', base_branch);
             core.setOutput('prs-string', prs.join('\n'));
-            
+
             combined = branches.join(' ')
             console.log('Combined: ' + combined);
             return combined
@@ -109,14 +108,14 @@ jobs:
           echo "${{steps.fetch-branch-names.outputs.result}}"
           sourcebranches="${BRANCHES_TO_COMBINE%\"}"
           sourcebranches="${sourcebranches#\"}"
-          
+
           basebranch="${BASE_BRANCH%\"}"
           basebranch="${basebranch#\"}"
-          
+
           git config pull.rebase false
           git config user.name github-actions
           git config user.email github-actions@github.com
-          
+
           git branch $COMBINE_BRANCH_NAME $basebranch
           git checkout $COMBINE_BRANCH_NAME
           git pull origin $sourcebranches --no-edit


### PR DESCRIPTION
Hi, thanks for your work to create this workflow! I was thinking the same way after seeing dependabot raise 6 PRs at a time, and I was delighted to find your blog post.

When I initially installed this workflow, it failed to select any PRs to combine. I noticed that I would always see `Validating status: pending` in the log for every PR, even if the PR had successfully passed all the build and test checks that I use.

I did a little googling and found this:

https://github.community/t/state-is-pending-statuses-are-missing-with-github-api-v3/14386

Which I think means that if people use GitHub actions to build/test their repo then the `/status` endpoint you're using in this workflow will never show the commit state as 'success'. I found I could fix the problem by switching to use the `/check-runs` endpoint and checking the 'conclusion' of each check run in the same way.

I'm not sure if this change is compatible with external CI systems that are not GitHub actions, so I understand if you don't want to merge this. I just wanted to raise the PR and share my code so that others can use this modification if they want to. I've tested this and the results look good to me.

I'm interested to know though, when you built this workflow were you using something like Travis to check PRs?